### PR TITLE
Fixed typo error of password template

### DIFF
--- a/HTTP_200/templates/account/login.html
+++ b/HTTP_200/templates/account/login.html
@@ -78,7 +78,7 @@
 				</div>
 				
 			</form>
-			<h4><a href="/"><i class="fa fa-chevron-left"></i> &nbsp;Back to home</a> <a href="{% url 'account_reset_password'%}" class="right">Forget Password</a></h4>
+			<h4><a href="/"><i class="fa fa-chevron-left"></i> &nbsp;Back to home</a> <a href="{% url 'account_reset_password'%}" class="right">Forgot Password</a></h4>
 		</div>
  <div class="modal-content">
 

--- a/HTTP_200/templates/account/password_reset.html
+++ b/HTTP_200/templates/account/password_reset.html
@@ -121,7 +121,7 @@
       <img src="{% static "images/logo-dark.png"%}"></a>
         </div>
         <h3 class="tag-line">Be updated anywhere and anytime!</h3>
-        <h3 class="index-welcome"><span class="index-bars"><i class="fa fa-bars"></i></span>Forget Password</h3>
+        <h3 class="index-welcome"><span class="index-bars"><i class="fa fa-bars"></i></span>Forgot Password</h3>
         </div>
         
         <div class="about-container contact-container">


### PR DESCRIPTION
I changed  `Forget Password` to `Forgot Password` in two files HTTP_200/templates/account/login.html and HTTP_200/templates/account/password_reset.html
@RishabhJain2018 I'm not sure this can fix your issue or not, could you please help me to check. Thank you