### PR TITLE
Notice admin updated

### DIFF
--- a/notices/admin.py
+++ b/notices/admin.py
@@ -1,17 +1,24 @@
 from django.contrib import admin
 from notices.models import Notice, BookmarkedNotice, TrendingInCollege
-from import_export.admin import ImportExportModelAdmin
 
+class BookmarkedNoticeAdmin(admin.TabularInline):
+    model = BookmarkedNotice
+    extra=1
+    fieldsets = (
+        (None, {
+            'classes': ('extrapretty','wide'),
+            'fields': (('user', 'notice'), 'pinned'),
+        }),
+    )
 
-class NoticeAdmin(ImportExportModelAdmin):
-    list_display = ('id','faculty', 'title', 'course_branch_year', 'created', 'modified', 'visible_for_student',
+class NoticeAdmin(admin.ModelAdmin):
+    list_display = ('faculty', 'title', 'course_branch_year', 'created', 'modified', 'visible_for_student',
                     'visible_for_faculty', 'visible_for_hod', 'visible_for_others', 'visible_for_management'
                     )
     list_display_links = ('title', 'faculty')
-    list_filter = ('category',)
-    list_per_page = 15
-    # search_fields = ['title', 'faculty']
-
+    list_filter = ('faculty', 'category')
+    list_per_page = 100
+    inlines = [BookmarkedNoticeAdmin]
     fieldsets = (
         (None, {
             'classes': ('wide', 'extrapretty'),
@@ -21,24 +28,8 @@ class NoticeAdmin(ImportExportModelAdmin):
         }),
     )
 
-
-class BookmarkedNoticeAdmin(ImportExportModelAdmin):
-    list_display = ('user', 'pinned', 'notice', )
-    # list_filter = ('notice',)
-    list_per_page = 25
-
-    fieldsets = (
-        (None, {
-            'classes': ('extrapretty'),
-            'fields': (('user', 'notice'), 'pinned'),
-        }),
-    )
-
-
-class TrendingInCollegeAdmin(ImportExportModelAdmin):
-    list_display = ('title', 'attachment', 'visibility')
-
+# class TrendingInCollegeAdmin(admin.ModelAdmin):
+#     list_display = ('title', 'attachment', 'visibility')
 
 admin.site.register(Notice, NoticeAdmin)
-admin.site.register(BookmarkedNotice, BookmarkedNoticeAdmin)
-admin.site.register(TrendingInCollege, TrendingInCollegeAdmin)
+# admin.site.register(TrendingInCollege, TrendingInCollegeAdmin)    #Unused model


### PR DESCRIPTION
Following PR fixes #52 and fixes #170 
Notices bookmarked by users are listed at end of that specific notice now.
**Admin Interface**
![notice_admin](https://user-images.githubusercontent.com/15031475/30813085-186fcbe2-a22a-11e7-986c-c6d75d6d7928.png)

**displaying bookmarked notice section at the end of edit notice menu**
![bookmarked_notice_view](https://user-images.githubusercontent.com/15031475/30813088-1a77ea46-a22a-11e7-9851-3db77119b159.png)
