### PR TITLE
Newsletters models and migration files added.

### DIFF
--- a/newsletters/migrations/0001_initial.py
+++ b/newsletters/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='department',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('department', models.CharField(max_length=50)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='papers',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=25)),
+                ('year', models.DateField()),
+                ('paper', models.FileField(upload_to=b'newsletters')),
+                ('department', models.ForeignKey(to='newsletters.department')),
+                ('uploaded_by', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/newsletters/models.py
+++ b/newsletters/models.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+
+class department(models.Model):
+    '''
+    Stores the detail of department linked with its newsletters
+    '''
+    department = models.CharField(max_length=50,
+                                  blank=False,
+                                  null=False)
+
+    def __unicode__(self):
+        return "%s" % (self.department)
+
+
+class papers(models.Model):
+    '''
+    Stores the pdfs of newsletters
+    '''
+    name = models.CharField(null=False,
+                            max_length=25)
+    uploaded_by = models.ForeignKey(User)
+    year = models.DateField()
+    paper = models.FileField(upload_to="newsletters", blank=False, null=False)
+    department = models.ForeignKey(department)
+
+    def __unicode__(self):
+        return "%s" % (self.name)


### PR DESCRIPTION
This PR contains the models and migration files for the infoconnect-newsletters section as developed in #232 .